### PR TITLE
[Coral-769] Fix `getPartitions` to work with compression

### DIFF
--- a/compiler/optimizer/src/main/java/edu/snu/coral/compiler/optimizer/pass/compiletime/composite/PrimitiveCompositePass.java
+++ b/compiler/optimizer/src/main/java/edu/snu/coral/compiler/optimizer/pass/compiletime/composite/PrimitiveCompositePass.java
@@ -34,7 +34,8 @@ public final class PrimitiveCompositePass extends CompositePass {
         new DefaultStagePartitioningPass(),
         new ReviseInterStageEdgeDataStorePass(), // after stage partitioning
         new DefaultEdgeUsedDataHandlingPass(),
-        new ScheduleGroupPass()
+        new ScheduleGroupPass(),
+        new CompressionPass()
     ));
   }
 }

--- a/compiler/optimizer/src/main/java/edu/snu/coral/compiler/optimizer/policy/DefaultPolicy.java
+++ b/compiler/optimizer/src/main/java/edu/snu/coral/compiler/optimizer/policy/DefaultPolicy.java
@@ -16,7 +16,6 @@
 package edu.snu.coral.compiler.optimizer.policy;
 
 import edu.snu.coral.compiler.optimizer.pass.compiletime.CompileTimePass;
-import edu.snu.coral.compiler.optimizer.pass.compiletime.annotating.CompressionPass;
 import edu.snu.coral.compiler.optimizer.pass.compiletime.composite.PrimitiveCompositePass;
 import edu.snu.coral.runtime.common.optimizer.pass.runtime.RuntimePass;
 
@@ -34,7 +33,6 @@ public final class DefaultPolicy implements Policy {
   public DefaultPolicy() {
     this.policy = new PolicyBuilder(true)
         .registerCompileTimePass(new PrimitiveCompositePass())
-        .registerCompileTimePass(new CompressionPass())
         .build();
   }
 

--- a/runtime/executor/src/main/java/edu/snu/coral/runtime/executor/data/LimitedInputStream.java
+++ b/runtime/executor/src/main/java/edu/snu/coral/runtime/executor/data/LimitedInputStream.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2018 Seoul National University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.snu.coral.runtime.executor.data;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * This class provide functionality to limit bytes read from {@link InputStream}.
+ */
+public final class LimitedInputStream extends InputStream {
+  private final InputStream in;
+  private long limit;
+
+  /**
+   * Constructor.
+   *
+   * @param in    {@link InputStream} that should be limited.
+   * @param limit bytes to limit.
+   * @throws IOException if failed to read stream.
+   */
+  public LimitedInputStream(final InputStream in, final long limit) {
+    this.in = in;
+    this.limit = limit;
+  }
+
+  @Override
+  public int read() throws IOException {
+    if (limit > 0) {
+      limit--;
+      return in.read();
+    } else {
+      return -1;
+    }
+  }
+}

--- a/runtime/executor/src/main/java/edu/snu/coral/runtime/executor/data/LimitedInputStream.java
+++ b/runtime/executor/src/main/java/edu/snu/coral/runtime/executor/data/LimitedInputStream.java
@@ -20,6 +20,8 @@ import java.io.InputStream;
 
 /**
  * This class provide functionality to limit bytes read from {@link InputStream}.
+ * You need to wrap chained compression stream with this stream to prevent overreading
+ * inner stream.
  */
 public final class LimitedInputStream extends InputStream {
   private final InputStream in;

--- a/runtime/executor/src/main/java/edu/snu/coral/runtime/executor/data/block/FileBlock.java
+++ b/runtime/executor/src/main/java/edu/snu/coral/runtime/executor/data/block/FileBlock.java
@@ -120,9 +120,12 @@ public final class FileBlock<K extends Serializable> implements Block<K> {
         final K key = partitionMetadata.getKey();
         if (keyRange.includes(key)) {
           // The key value of this partition is in the range.
+          final byte[] serializedData = new byte[partitionMetadata.getPartitionSize()];
+          fileStream.read(serializedData);
+          final ByteArrayInputStream byteInputStream = new ByteArrayInputStream(serializedData);
           final NonSerializedPartition<K> deserializePartition =
               DataUtil.deserializePartition(
-                  partitionMetadata.getElementsTotal(), serializer, key, fileStream);
+                  partitionMetadata.getElementsTotal(), serializer, key, byteInputStream);
           deserializedPartitions.add(deserializePartition);
         } else {
           // Have to skip this partition.

--- a/runtime/executor/src/main/java/edu/snu/coral/runtime/executor/data/block/FileBlock.java
+++ b/runtime/executor/src/main/java/edu/snu/coral/runtime/executor/data/block/FileBlock.java
@@ -121,6 +121,9 @@ public final class FileBlock<K extends Serializable> implements Block<K> {
         if (keyRange.includes(key)) {
           // The key value of this partition is in the range.
           final long availableBefore = fileStream.available();
+          // We need to limit read bytes on this FileStream, which could be overread by wrapped
+          // compression stream. We recommend to wrap with LimitedInputStream once more when
+          // reading input from chained compression InputStream.
           final LimitedInputStream limitedInputStream =
               new LimitedInputStream(fileStream, partitionMetadata.getPartitionSize());
           final NonSerializedPartition<K> deserializePartition =

--- a/runtime/executor/src/main/java/edu/snu/coral/runtime/executor/data/block/FileBlock.java
+++ b/runtime/executor/src/main/java/edu/snu/coral/runtime/executor/data/block/FileBlock.java
@@ -120,13 +120,12 @@ public final class FileBlock<K extends Serializable> implements Block<K> {
         final K key = partitionMetadata.getKey();
         if (keyRange.includes(key)) {
           // The key value of this partition is in the range.
-          final byte[] serializedData = new byte[partitionMetadata.getPartitionSize()];
-          fileStream.read(serializedData);
-          final ByteArrayInputStream byteInputStream = new ByteArrayInputStream(serializedData);
+          final long availableBefore = fileStream.available();
           final NonSerializedPartition<K> deserializePartition =
               DataUtil.deserializePartition(
-                  partitionMetadata.getElementsTotal(), serializer, key, byteInputStream);
+                  partitionMetadata.getElementsTotal(), serializer, key, fileStream);
           deserializedPartitions.add(deserializePartition);
+          skipBytes(fileStream, partitionMetadata.getPartitionSize() - availableBefore + fileStream.available());
         } else {
           // Have to skip this partition.
           skipBytes(fileStream, partitionMetadata.getPartitionSize());

--- a/tests/src/test/java/edu/snu/coral/tests/compiler/optimizer/policy/PolicyBuilderTest.java
+++ b/tests/src/test/java/edu/snu/coral/tests/compiler/optimizer/policy/PolicyBuilderTest.java
@@ -14,21 +14,21 @@ public final class PolicyBuilderTest {
   @Test
   public void testDisaggregationPolicy() {
     final Policy disaggregationPolicy = new DisaggregationPolicy();
-    assertEquals(10, disaggregationPolicy.getCompileTimePasses().size());
+    assertEquals(11, disaggregationPolicy.getCompileTimePasses().size());
     assertEquals(0, disaggregationPolicy.getRuntimePasses().size());
   }
 
   @Test
   public void testPadoPolicy() {
     final Policy padoPolicy = new PadoPolicy();
-    assertEquals(12, padoPolicy.getCompileTimePasses().size());
+    assertEquals(13, padoPolicy.getCompileTimePasses().size());
     assertEquals(0, padoPolicy.getRuntimePasses().size());
   }
 
   @Test
   public void testDataSkewPolicy() {
     final Policy dataSkewPolicy = new DataSkewPolicy();
-    assertEquals(14, dataSkewPolicy.getCompileTimePasses().size());
+    assertEquals(15, dataSkewPolicy.getCompileTimePasses().size());
     assertEquals(1, dataSkewPolicy.getRuntimePasses().size());
   }
 

--- a/tests/src/test/java/edu/snu/coral/tests/runtime/executor/data/BlockStoreTest.java
+++ b/tests/src/test/java/edu/snu/coral/tests/runtime/executor/data/BlockStoreTest.java
@@ -15,6 +15,7 @@
  */
 package edu.snu.coral.tests.runtime.executor.data;
 
+import edu.snu.coral.common.ir.edge.executionproperty.CompressionProperty;
 import edu.snu.coral.conf.JobConf;
 import edu.snu.coral.compiler.frontend.beam.coder.BeamCoder;
 import edu.snu.coral.common.coder.Coder;
@@ -26,6 +27,7 @@ import edu.snu.coral.runtime.common.message.local.LocalMessageDispatcher;
 import edu.snu.coral.runtime.common.message.local.LocalMessageEnvironment;
 import edu.snu.coral.runtime.common.state.BlockState;
 import edu.snu.coral.runtime.executor.data.*;
+import edu.snu.coral.runtime.executor.data.streamchainer.CompressionStreamChainer;
 import edu.snu.coral.runtime.executor.data.streamchainer.Serializer;
 import edu.snu.coral.runtime.executor.data.stores.*;
 import edu.snu.coral.runtime.master.BlockManagerMaster;
@@ -70,7 +72,8 @@ import static org.mockito.Mockito.when;
 public final class BlockStoreTest {
   private static final String TMP_FILE_DIRECTORY = "./tmpFiles";
   private static final Coder CODER = new BeamCoder(KvCoder.of(VarIntCoder.of(), VarIntCoder.of()));
-  private static final Serializer SERIALIZER = new Serializer(CODER, Collections.emptyList());
+  private static final Serializer SERIALIZER = new Serializer(CODER,
+      Collections.singletonList(new CompressionStreamChainer(CompressionProperty.Compression.LZ4)));
   private static final SerializerManager serializerManager = mock(SerializerManager.class);
   private BlockManagerMaster blockManagerMaster;
   private LocalMessageDispatcher messageDispatcher;
@@ -593,7 +596,7 @@ public final class BlockStoreTest {
     }
     final Iterable<NonSerializedPartition> nonSerializedResult = optionalNonSerResult.get();
     final Iterable serToNonSerialized = DataUtil.convertToNonSerPartitions(
-        new Serializer(CODER, Collections.emptyList()), serializedResult);
+        SERIALIZER, serializedResult);
 
     assertEquals(expectedResult, DataUtil.concatNonSerPartitions(nonSerializedResult));
     assertEquals(expectedResult, DataUtil.concatNonSerPartitions(serToNonSerialized));


### PR DESCRIPTION
* Fix `FileBlock#getPartitions` to skip unread bytes.
* `LimitedInputStream` implementation for limiting overreading `FileInputStream`.
* Add compression to `BlockStoreTest`.
* Add `CompressionPass` in `PrimitiveCompositePass`.

This PR fixes an issue about `DataSkewRuntimePass` not working properly with `CompressionPass`.

Resolves #769 